### PR TITLE
Convert timestamp to timedelta just after reading traces

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "testing-tools"
-version = "0.1.0"
+version = "0.0.2"
 dependencies = []
 requires-python = ">=3.12"
 authors = [

--- a/testing_tools/result_entry.py
+++ b/testing_tools/result_entry.py
@@ -1,14 +1,11 @@
 import re
-from datetime import datetime
 from typing import Dict
 
 
 class ResultEntry:
     def __init__(self, json_message: Dict):
         for key in json_message:
-            if key == "timestamp":
-                self._add_attribute(key, datetime.fromisoformat(json_message[key]))
-            elif key == "fields":
+            if key == "fields":
                 for inner_key in json_message[key]:
                     self._add_attribute(inner_key, json_message[key][inner_key])
             else:

--- a/testing_tools/runtime.py
+++ b/testing_tools/runtime.py
@@ -1,5 +1,6 @@
 import json
 import os
+from datetime import timedelta
 from pathlib import Path
 from subprocess import PIPE, Popen, TimeoutExpired
 
@@ -40,9 +41,14 @@ def execute_and_parse(test_config, test_case_name, expect_hang):
     raw_messages = outs.strip().split("\n")
     # Filter non-json messages
     raw_messages = [message for message in raw_messages if message.startswith("{") and message.endswith("}")]
+    messages = [json.loads(message) for message in raw_messages]
+
+    # Convert timestamp from microseconds to timedelta
+    messages = list(
+        map(lambda message: {**message, "timestamp": timedelta(microseconds=int(message["timestamp"]))}, messages)
+    )
 
     # Messages may not be in the chronological order
-    messages = [json.loads(message) for message in raw_messages]
     messages.sort(key=lambda m: m["timestamp"])
 
     return messages

--- a/tests/test_log_container_and_result_entry.py
+++ b/tests/test_log_container_and_result_entry.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import timedelta
 
 from testing_tools.log_container import LogContainer
 from testing_tools.result_entry import ResultEntry
@@ -9,7 +9,7 @@ def test_log_container_add_and_get_logs():
     lc.add_log(
         ResultEntry(
             {
-                "timestamp": "2025-06-05T07:46:11.796134Z",
+                "timestamp": "0:00:01.000100",
                 "level": "DEBUG",
                 "fields": {"message": "Debug message"},
                 "target": "target::DEBUG_message",
@@ -20,7 +20,7 @@ def test_log_container_add_and_get_logs():
     lc.add_log(
         ResultEntry(
             {
-                "timestamp": "2025-06-05T07:46:11.799245Z",
+                "timestamp": "0:00:01.000101",
                 "level": "INFO",
                 "target": "target::INFO_message",
                 "threadId": "ThreadId(2)",
@@ -30,13 +30,13 @@ def test_log_container_add_and_get_logs():
     logs = lc.get_logs()
     assert len(logs) == 2
 
-    assert logs[0].timestamp == datetime.fromisoformat("2025-06-05T07:46:11.796134Z")
+    assert logs[0].timestamp == str(timedelta(microseconds=1000100))
     assert logs[0].level == "DEBUG"
     assert logs[0].message == "Debug message"
     assert logs[0].target == "target::DEBUG_message"
     assert logs[0].thread_id == "ThreadId(1)"
 
-    assert logs[1].timestamp == datetime.fromisoformat("2025-06-05T07:46:11.799245Z")
+    assert logs[1].timestamp == str(timedelta(microseconds=1000101))
     assert logs[1].level == "INFO"
     assert logs[1].target == "target::INFO_message"
     assert logs[1].thread_id == "ThreadId(2)"
@@ -47,7 +47,7 @@ def test_log_container_find_log():
     lc.add_log(
         ResultEntry(
             {
-                "timestamp": "2025-06-05T07:46:11.796134Z",
+                "timestamp": "0:01:01.000100",
                 "level": "DEBUG",
                 "fields": {"message": "Debug message"},
                 "target": "target::DEBUG_message",
@@ -58,7 +58,7 @@ def test_log_container_find_log():
     lc.add_log(
         ResultEntry(
             {
-                "timestamp": "2025-06-05T07:46:11.799245Z",
+                "timestamp": "0:01:01.000100",
                 "level": "INFO",
                 "target": "target::INFO_message",
                 "threadId": "ThreadId(2)",
@@ -77,7 +77,7 @@ def test_log_container_get_logs_by_field():
     lc.add_log(
         ResultEntry(
             {
-                "timestamp": "2025-06-05T07:46:11.796134Z",
+                "timestamp": "0:01:01.000100",
                 "level": "DEBUG",
                 "fields": {"message": "Debug message 1"},
                 "target": "target::DEBUG_message",
@@ -88,7 +88,7 @@ def test_log_container_get_logs_by_field():
     lc.add_log(
         ResultEntry(
             {
-                "timestamp": "2025-06-05T07:46:11.796134Z",
+                "timestamp": "0:01:01.000100",
                 "level": "DEBUG",
                 "fields": {"message": "Debug message 2"},
                 "target": "target::DEBUG_message",
@@ -107,7 +107,7 @@ def test_log_container_clear_logs():
     lc.add_log(
         ResultEntry(
             {
-                "timestamp": "2025-06-05T07:46:11.799245Z",
+                "timestamp": "0:00:01.000100",
                 "level": "INFO",
                 "fields": {"message": "Info message"},
                 "target": "target::INFO_message",

--- a/tests/test_result_entry.py
+++ b/tests/test_result_entry.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import timedelta
 
 from testing_tools.result_entry import ResultEntry
 
@@ -7,13 +7,13 @@ from testing_tools.result_entry import ResultEntry
 def test_result_entry_creation_and_properties():
     entry = ResultEntry(
         {
-            "timestamp": "2025-06-05T07:46:11.796134Z",
+            "timestamp": "0:00:00.000001",
             "level": "DEBUG",
             "target": "target::DEBUG_message",
             "threadId": "ThreadId(1)",
         }
     )
-    assert entry.timestamp == datetime.fromisoformat("2025-06-05T07:46:11.796134Z")
+    assert entry.timestamp == str(timedelta(microseconds=1))
     assert entry.level == "DEBUG"
     assert entry.target == "target::DEBUG_message"
     assert entry.thread_id == "ThreadId(1)"
@@ -22,7 +22,7 @@ def test_result_entry_creation_and_properties():
 def test_result_orchestration_creation_and_properties():
     entry = ResultEntry(
         {
-            "timestamp": "2025-06-05T07:46:11.796134Z",
+            "timestamp": "0:00:00.000010",
             "level": "DEBUG",
             "fields": {"message": "Debug message"},
             "target": "target::DEBUG_message",
@@ -30,7 +30,7 @@ def test_result_orchestration_creation_and_properties():
         }
     )
 
-    assert entry.timestamp == datetime.fromisoformat("2025-06-05T07:46:11.796134Z")
+    assert entry.timestamp == str(timedelta(microseconds=10))
     assert entry.level == "DEBUG"
     assert entry.message == "Debug message"
     assert entry.target == "target::DEBUG_message"
@@ -40,7 +40,7 @@ def test_result_orchestration_creation_and_properties():
 def test_result_entry_str():
     entry = ResultEntry(
         {
-            "timestamp": "2025-06-05T07:46:11.796134Z",
+            "timestamp": "0:00:01.000100",
             "level": "DEBUG",
             "fields": {"message": "Debug message"},
             "target": "target::DEBUG_message",
@@ -48,7 +48,7 @@ def test_result_entry_str():
         }
     )
     str_repr = str(entry)
-    assert "timestamp=2025-06-05 07:46:11.796134+00:00" in str_repr
+    assert "timestamp=0:00:01.0001" in str_repr
     assert "level=DEBUG" in str_repr
     assert "target=target::DEBUG_message" in str_repr
     assert "thread_id=ThreadId(1)" in str_repr


### PR DESCRIPTION
Wall clock was replaced with monotonic clock
Early conversion makes it easier for logging and later processing