### PR TITLE
impl: allow exact and regex matching in LogContainer filters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "testing-utils"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = ["pytest"]
 requires-python = ">=3.12"
 authors = [

--- a/testing_utils/log_container.py
+++ b/testing_utils/log_container.py
@@ -243,13 +243,9 @@ class LogContainer:
         """
         return self._logs[:]
 
-    def clear_logs(self):
-        """
-        Clear all logs.
-        """
-        self._logs.clear()
-
-    def remove_logs(self, field: str, *, pattern: str | _NotSet = _not_set, value: Any | _NotSet = _not_set):
+    def remove_logs(
+        self, field: str, *, pattern: str | _NotSet = _not_set, value: Any | _NotSet = _not_set
+    ) -> "LogContainer":
         """
         Remove all logs matching the given field and pattern or value.
 
@@ -265,7 +261,7 @@ class LogContainer:
             Exact value to match.
             Mutually exclusive with "pattern".
         """
-        self._logs = self._logs_by_field(field, reverse=True, pattern=pattern, value=value)
+        return LogContainer(self._logs_by_field(field, reverse=True, pattern=pattern, value=value))
 
     def group_by(self, attribute: str) -> dict[str, "LogContainer"]:
         """

--- a/testing_utils/log_container.py
+++ b/testing_utils/log_container.py
@@ -7,6 +7,7 @@ __all__ = ["LogContainer"]
 import re
 from itertools import groupby
 from operator import attrgetter
+from typing import Any
 
 from .result_entry import ResultEntry
 
@@ -52,11 +53,101 @@ class LogContainer:
         """
         return self._logs[subscript]
 
-    def contains_log(self, field: str, pattern: str) -> bool:
+    class _NotFound:
+        """
+        Internal type for failed search results.
+        """
+
+    _not_found = _NotFound()
+
+    def _logs_by_field_str(self, field: str, pattern: str, excluded: bool) -> list[ResultEntry]:
+        """
+        Filter entries using regex matching.
+
+        Parameters
+        ----------
+        field : str
+            Name of the field to match.
+        pattern : str
+            Regex pattern to match.
+        excluded : bool
+            Return entries not matched.
+        """
+        entries = []
+        regex = re.compile(pattern)
+        for log in self._logs:
+            found_value = getattr(log, field, self._not_found)
+            if found_value == self._not_found:
+                continue
+            if not isinstance(found_value, type(pattern)):
+                raise TypeError(
+                    f"Type mismatch, provided value type: {type(pattern)}, found value type: {type(found_value)}"
+                )
+            found = regex.search(found_value) is not None
+            if found ^ excluded:
+                entries.append(log)
+        return entries
+
+    def _logs_by_field_any(self, field: str, pattern: Any, excluded: bool) -> list[ResultEntry]:
+        """
+        Filter entries by value.
+
+        Parameters
+        ----------
+        field : str
+            Name of the field to match.
+        pattern : Any
+            Pattern to match.
+        excluded : bool
+            Return entries not matched.
+        """
+        entries = []
+        for log in self._logs:
+            found_value = getattr(log, field, self._not_found)
+            if found_value == self._not_found:
+                continue
+            if not isinstance(found_value, type(pattern)):
+                raise TypeError(
+                    f"Type mismatch, provided value type: {type(pattern)}, found value type: {type(found_value)}"
+                )
+            found = found_value == pattern
+            if found ^ excluded:
+                entries.append(log)
+        return entries
+
+    def _logs_by_field(self, field: str, pattern: Any, excluded: bool) -> list[ResultEntry]:
+        """
+        Filter entries by type specific filtering method.
+
+        Parameters
+        ----------
+        field : str
+            Name of the field to match.
+        pattern : Any
+            Pattern to match.
+            Regex match is used for 'str' values.
+        excluded : bool
+            Return entries not matched.
+        """
+
+        if isinstance(pattern, str):
+            return self._logs_by_field_str(field, pattern, excluded)
+        else:
+            return self._logs_by_field_any(field, pattern, excluded)
+
+    def contains_log(self, field: str, pattern: Any) -> bool:
         """
         Check if a LogContainer contains a ResultEntry with the given field and pattern.
+
+        Parameters
+        ----------
+        field : str
+            Name of the field to match.
+        pattern : Any
+            Pattern to match.
+            Regex match is used for 'str' values.
         """
-        return any(log for log in self.get_logs_by_field(field, pattern))
+        return len(self._logs_by_field(field, pattern, False)) > 0
 
     def contains_id(self, entry_id: str) -> bool:
         """
@@ -64,21 +155,35 @@ class LogContainer:
         """
         return any(log.id == entry_id for log in self._logs)
 
-    def get_logs_by_field(self, field: str, pattern: str) -> "LogContainer":
+    def get_logs_by_field(self, field: str, pattern: Any) -> "LogContainer":
         """
         Get all ResultEntry messages that match the given field and pattern.
-        """
-        regex = re.compile(pattern)
-        entries = [log for log in self._logs if regex.search(getattr(log, field, ""))]
-        return LogContainer(entries)
 
-    def find_log(self, field: str, pattern: str) -> ResultEntry | None:
+        Parameters
+        ----------
+        field : str
+            Name of the field to match.
+        pattern : Any
+            Pattern to match.
+            Regex match is used for 'str' values.
+        """
+        return LogContainer(self._logs_by_field(field, pattern, False))
+
+    def find_log(self, field: str, pattern: Any) -> ResultEntry | None:
         """
         Find a ResultEntry message that matches the given field and pattern.
         Returns the first match or None if no match is found.
         Raises ValueError if multiple matches are found.
+
+        Parameters
+        ----------
+        field : str
+            Name of the field to match.
+        pattern : Any
+            Pattern to match.
+            Regex match is used for 'str' values.
         """
-        findings = self.get_logs_by_field(field, pattern)
+        findings = self._logs_by_field(field, pattern, False)
         if len(findings) == 1:
             return findings[0]
         if len(findings) > 1:
@@ -114,12 +219,19 @@ class LogContainer:
         """
         self._logs.clear()
 
-    def remove_logs(self, field: str, pattern: str):
+    def remove_logs(self, field: str, pattern: Any):
         """
         Remove all ResultEntry messages that match the given field and pattern.
+
+        Parameters
+        ----------
+        field : str
+            Name of the field to match.
+        pattern : Any
+            Pattern to match.
+            Regex match is used for 'str' values.
         """
-        regex = re.compile(pattern)
-        self._logs = [log for log in self._logs if not regex.search(getattr(log, field, ""))]
+        self._logs = self._logs_by_field(field, pattern, True)
 
     def group_by(self, attribute: str) -> dict[str, "LogContainer"]:
         """

--- a/tests/test_log_container.py
+++ b/tests/test_log_container.py
@@ -750,16 +750,6 @@ class TestGetLogs:
         assert len(logs) == 0
 
 
-class TestClearLogs:
-    """
-    Tests for `clear_logs`.
-    """
-
-    def test_ok(self, lc_basic: LogContainer):
-        lc_basic.clear_logs()
-        assert lc_basic.get_logs() == []
-
-
 class TestRemoveLogs:
     """
     Tests for `remove_logs`.
@@ -784,9 +774,7 @@ class TestRemoveLogs:
                 ResultEntry({"level": "WARN"}),
             ]
         )
-        lc.remove_logs("level", pattern=r"WARN|INFO")
-
-        logs = lc.get_logs()
+        logs = lc.remove_logs("level", pattern=r"WARN|INFO")
         assert len(logs) == 1
         assert logs[0].level == "DEBUG"
 
@@ -803,9 +791,7 @@ class TestRemoveLogs:
                 ResultEntry({"someId": 12}),
             ]
         )
-        lc.remove_logs("some_id", pattern=r"^1$")
-
-        logs = lc.get_logs()
+        logs = lc.remove_logs("some_id", pattern=r"^1$")
         assert len(logs) == 4
         assert logs[0].some_id == 2
         assert logs[1].some_id == 3
@@ -823,9 +809,7 @@ class TestRemoveLogs:
                 ResultEntry({"level": "DEBUG", "someId": 100}),
             ]
         )
-        lc.remove_logs("some_id", pattern="^0$")
-
-        logs = lc.get_logs()
+        logs = lc.remove_logs("some_id", pattern="^0$")
         assert len(logs) == 3
         assert logs[0].some_id == 6543
         assert logs[1].some_id == "10"
@@ -840,8 +824,8 @@ class TestRemoveLogs:
                 ResultEntry({"level": "WARN"}),
             ]
         )
-        lc.remove_logs("invalid", pattern="WARN")
-        assert len(lc) == 3
+        logs = lc.remove_logs("invalid", pattern="WARN")
+        assert len(logs) == 3
 
     def test_pattern_invalid_value(self):
         lc = LogContainer()
@@ -852,8 +836,8 @@ class TestRemoveLogs:
                 ResultEntry({"level": "WARN"}),
             ]
         )
-        lc.remove_logs("level", pattern="invalid")
-        assert len(lc) == 3
+        logs = lc.remove_logs("level", pattern="invalid")
+        assert len(logs) == 3
 
     def test_value_str_ok(self):
         lc = LogContainer()
@@ -864,9 +848,7 @@ class TestRemoveLogs:
                 ResultEntry({"level": "WARN"}),
             ]
         )
-        lc.remove_logs("level", value="INFO")
-
-        logs = lc.get_logs()
+        logs = lc.remove_logs("level", value="INFO")
         assert len(logs) == 2
         assert logs[0].level == "DEBUG"
         assert logs[1].level == "WARN"
@@ -884,9 +866,7 @@ class TestRemoveLogs:
                 ResultEntry({"someId": 12}),
             ]
         )
-        lc.remove_logs("some_id", value=1)
-
-        logs = lc.get_logs()
+        logs = lc.remove_logs("some_id", value=1)
         assert len(logs) == 4
         assert logs[0].some_id == 2
         assert logs[1].some_id == 3
@@ -904,9 +884,7 @@ class TestRemoveLogs:
                 ResultEntry({"level": "INFO", "someId": 1}),
             ]
         )
-        lc.remove_logs("some_id", value=None)
-
-        logs = lc.get_logs()
+        logs = lc.remove_logs("some_id", value=None)
         assert len(logs) == 4
         assert all(log is not None for log in logs)
 
@@ -922,20 +900,19 @@ class TestRemoveLogs:
             ]
         )
 
-        lc.remove_logs("some_id", value="0")
-        logs = lc.get_logs()
+        logs = lc.remove_logs("some_id", value="0")
         assert len(logs) == 4
         assert logs[0].some_id == 0
         assert logs[1].some_id == 6543
         assert logs[2].some_id == "10"
         assert logs[3].some_id == 100
 
-        lc.remove_logs("some_id", value=0)
-        logs = lc.get_logs()
-        assert len(logs) == 3
-        assert logs[0].some_id == 6543
-        assert logs[1].some_id == "10"
-        assert logs[2].some_id == 100
+        logs = lc.remove_logs("some_id", value=0)
+        assert len(logs) == 4
+        assert logs[0].some_id == "0"
+        assert logs[1].some_id == 6543
+        assert logs[2].some_id == "10"
+        assert logs[3].some_id == 100
 
     def test_value_invalid_field(self):
         lc = LogContainer()
@@ -946,8 +923,8 @@ class TestRemoveLogs:
                 ResultEntry({"level": "WARN"}),
             ]
         )
-        lc.remove_logs("invalid", value="WARN")
-        assert len(lc) == 3
+        logs = lc.remove_logs("invalid", value="WARN")
+        assert len(logs) == 3
 
     def test_value_invalid_str_value(self):
         lc = LogContainer()
@@ -958,8 +935,8 @@ class TestRemoveLogs:
                 ResultEntry({"level": "WARN"}),
             ]
         )
-        lc.remove_logs("level", value="invalid")
-        assert len(lc) == 3
+        logs = lc.remove_logs("level", value="invalid")
+        assert len(logs) == 3
 
     def test_value_invalid_int_value(self):
         lc = LogContainer()
@@ -972,8 +949,8 @@ class TestRemoveLogs:
                 ResultEntry({"someId": 1}),
             ]
         )
-        lc.remove_logs("some_id", value=10)
-        assert len(lc) == 5
+        logs = lc.remove_logs("some_id", value=10)
+        assert len(logs) == 5
 
 
 class TestGroupBy:

--- a/tests/test_log_container.py
+++ b/tests/test_log_container.py
@@ -287,6 +287,59 @@ def test_log_container_get_logs_by_field_int():
     assert all(log.some_id == 1 for log in logs)
 
 
+def test_log_container_get_logs_by_field_none():
+    lc = LogContainer()
+    lc.add_log(
+        [
+            ResultEntry({"level": "DEBUG", "someId": 1}),
+            ResultEntry({"level": "DEBUG", "someId": 2}),
+            ResultEntry({"level": "INFO", "someId": None}),
+            ResultEntry({"level": "WARN", "someId": 2}),
+            ResultEntry({"level": "INFO", "someId": 1}),
+        ]
+    )
+    logs = lc.get_logs_by_field("some_id", None)
+    assert len(logs) == 1
+    assert logs[0].some_id is None
+
+def test_log_container_get_logs_by_field_invalid_key():
+    lc = LogContainer()
+    lc.add_log(
+        [
+            ResultEntry({"level": "DEBUG"}),
+            ResultEntry({"level": "INFO"}),
+            ResultEntry({"level": "WARN"}),
+        ]
+    )
+    logs = lc.get_logs_by_field("invalid_entry", "invalid_pattern")
+    assert len(logs) == 0
+
+def test_log_container_get_logs_by_field_invalid_pattern_str():
+    lc = LogContainer()
+    lc.add_log(
+        [
+            ResultEntry({"level": "DEBUG"}),
+            ResultEntry({"level": "INFO"}),
+            ResultEntry({"level": "WARN"}),
+        ]
+    )
+    logs = lc.get_logs_by_field("level", "invalid_pattern")
+    assert len(logs) == 0
+
+def test_log_container_get_logs_by_field_invalid_pattern_int():
+    lc = LogContainer()
+    lc.add_log(
+        [
+            ResultEntry({"someId": 1}),
+            ResultEntry({"someId": 2}),
+            ResultEntry({"someId": 3}),
+            ResultEntry({"someId": 1}),
+            ResultEntry({"someId": 1}),
+        ]
+    )
+    logs = lc.get_logs_by_field("some_id", 10)
+    assert len(logs) == 0
+
 def test_log_container_remove_logs_str():
     lc = LogContainer()
     lc.add_log(

--- a/tests/test_log_container.py
+++ b/tests/test_log_container.py
@@ -3,54 +3,667 @@ Tests for "log_container" module.
 """
 
 from datetime import timedelta
+from typing import Any
 
 import pytest
 
 from testing_utils import LogContainer, ResultEntry
 
 
-def test_log_container_add_and_get_logs():
-    lc = LogContainer()
-    lc.add_log(
-        ResultEntry(
-            {
-                "timestamp": "0:00:01.000100",
-                "level": "DEBUG",
-                "fields": {"message": "Debug message"},
-                "target": "target::DEBUG_message",
-                "threadId": "ThreadId(1)",
-            }
+@pytest.fixture
+def lc_basic() -> LogContainer:
+    """
+    Basic log container provider.
+    """
+    entries = [ResultEntry({"index": i}) for i in range(10)]
+    return LogContainer(entries)
+
+
+class TestInit:
+    """
+    Tests for `__init__`.
+    """
+
+    def test_ok(self, lc_basic: LogContainer):
+        # Construction happens in fixture.
+        assert len(lc_basic) == 10
+
+    def test_default_empty(self):
+        # Make sure internal storage is always list.
+        lc = LogContainer()
+        assert len(lc) == 0
+        assert isinstance(lc.get_logs(), list)
+
+    def test_explicit_none(self):
+        # Make sure internal storage is always list.
+        lc = LogContainer(None)
+        assert len(lc) == 0
+        assert isinstance(lc.get_logs(), list)
+
+    def test_default_param_not_referenced(self):
+        lc1 = LogContainer()
+        lc1.add_log(ResultEntry({}))
+        lc2 = LogContainer()
+        lc2.add_log(ResultEntry({}))
+
+        assert len(lc1.get_logs()) == 1
+        assert len(lc2.get_logs()) == 1
+
+    def test_param_copied_not_referenced(self):
+        logs1 = [ResultEntry({})]
+        lc1 = LogContainer(logs1)
+        lc1.add_log(ResultEntry({}))
+        lc2 = LogContainer()
+        lc2.add_log(ResultEntry({}))
+
+        assert len(logs1) == 1
+        assert len(lc1.get_logs()) == 2
+        assert len(lc2.get_logs()) == 1
+
+
+class TestIterNext:
+    """
+    Tests for `__iter__` and `__next__`.
+    """
+
+    def test_ok(self, lc_basic: LogContainer):
+        for i, log in enumerate(lc_basic):
+            assert log.index == i
+
+    def test_empty(self):
+        lc = LogContainer()
+        for _ in lc:
+            assert False, "Statement shouldn't be reached"
+
+
+class TestLen:
+    """
+    Tests for `__len__`.
+    """
+
+    def test_ok(self):
+        lc = LogContainer([ResultEntry({}), ResultEntry({}), ResultEntry({})])
+        assert len(lc) == 3
+
+    def test_empty(self):
+        lc = LogContainer()
+        assert len(lc) == 0
+
+
+class TestGetItem:
+    """
+    Tests for `__getitem__`.
+    """
+
+    def test_ok(self, lc_basic: LogContainer):
+        for i in range(10):
+            assert lc_basic[i].index == i
+
+    def test_out_of_range(self, lc_basic: LogContainer):
+        with pytest.raises(IndexError):
+            _ = lc_basic[20]
+
+    def test_negative(self, lc_basic: LogContainer):
+        assert lc_basic[-1].index == 9
+
+
+class TestContainsLog:
+    """
+    Tests for `contains_logs`.
+    """
+
+    def test_both_pattern_and_value(self):
+        lc = LogContainer()
+        with pytest.raises(RuntimeError):
+            _ = lc.contains_log("level", pattern="pattern", value="value")
+
+    def test_neither_pattern_nor_value(self):
+        lc = LogContainer()
+        with pytest.raises(RuntimeError):
+            _ = lc.contains_log("level")
+
+    def test_pattern_str_ok(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG"}),
+                ResultEntry({"level": "INFO"}),
+                ResultEntry({"level": "WARN"}),
+            ]
         )
-    )
-    lc.add_log(
-        ResultEntry(
-            {
-                "timestamp": "0:00:01.000101",
-                "level": "INFO",
-                "target": "target::INFO_message",
-                "threadId": "ThreadId(2)",
-            }
+        assert lc.contains_log("level", pattern=r"WARN|INFO")
+
+    def test_pattern_int_ok(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"someId": 1}),
+                ResultEntry({"someId": 2}),
+                ResultEntry({"someId": 3}),
+                ResultEntry({"someId": 1}),
+                ResultEntry({"someId": 1}),
+                ResultEntry({"someId": 11}),
+                ResultEntry({"someId": 12}),
+            ]
         )
-    )
-    logs = lc.get_logs()
-    assert len(logs) == 2
+        assert lc.contains_log("some_id", pattern=r"^1$")
 
-    assert logs[0].timestamp == str(timedelta(microseconds=1000100))
-    assert logs[0].level == "DEBUG"
-    assert logs[0].message == "Debug message"
-    assert logs[0].target == "target::DEBUG_message"
-    assert logs[0].thread_id == "ThreadId(1)"
+    def test_pattern_cast_type(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG", "someId": "0"}),
+                ResultEntry({"level": "DEBUG", "someId": 0}),
+                ResultEntry({"level": "DEBUG", "someId": 6543}),
+                ResultEntry({"level": "DEBUG", "someId": "10"}),
+                ResultEntry({"level": "DEBUG", "someId": 100}),
+            ]
+        )
+        assert lc.contains_log("some_id", pattern="^0$")
+        assert lc.contains_log("some_id", pattern="0")
 
-    assert logs[1].timestamp == str(timedelta(microseconds=1000101))
-    assert logs[1].level == "INFO"
-    assert logs[1].target == "target::INFO_message"
-    assert logs[1].thread_id == "ThreadId(2)"
+    def test_pattern_invalid_field(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG"}),
+                ResultEntry({"level": "INFO"}),
+                ResultEntry({"level": "WARN"}),
+            ]
+        )
+        assert not lc.contains_log("invalid", pattern="WARN")
+
+    def test_pattern_invalid_value(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG"}),
+                ResultEntry({"level": "INFO"}),
+                ResultEntry({"level": "WARN"}),
+            ]
+        )
+        assert not lc.contains_log("level", pattern="invalid")
+
+    def test_value_str_ok(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG"}),
+                ResultEntry({"level": "INFO"}),
+                ResultEntry({"level": "WARN"}),
+            ]
+        )
+        assert lc.contains_log("level", value="INFO")
+
+    def test_value_int_ok(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"someId": 1}),
+                ResultEntry({"someId": 2}),
+                ResultEntry({"someId": 3}),
+                ResultEntry({"someId": 1}),
+                ResultEntry({"someId": 1}),
+                ResultEntry({"someId": 11}),
+                ResultEntry({"someId": 12}),
+            ]
+        )
+        assert lc.contains_log("some_id", value=1)
+
+    def test_value_none_ok(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG", "someId": 1}),
+                ResultEntry({"level": "DEBUG", "someId": 2}),
+                ResultEntry({"level": "INFO", "someId": None}),
+                ResultEntry({"level": "WARN", "someId": 2}),
+                ResultEntry({"level": "INFO", "someId": 1}),
+            ]
+        )
+        assert lc.contains_log("some_id", value=None)
+
+    def test_value_filter_type(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG", "someId": "0"}),
+                ResultEntry({"level": "DEBUG", "someId": 0}),
+                ResultEntry({"level": "DEBUG", "someId": 6543}),
+                ResultEntry({"level": "DEBUG", "someId": "10"}),
+                ResultEntry({"level": "DEBUG", "someId": 100}),
+            ]
+        )
+        assert lc.contains_log("some_id", value="0")
+        assert lc.contains_log("some_id", value=0)
+
+    def test_value_invalid_field(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG"}),
+                ResultEntry({"level": "INFO"}),
+                ResultEntry({"level": "WARN"}),
+            ]
+        )
+        assert not lc.contains_log("invalid", value="WARN")
+
+    def test_value_invalid_str_value(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG"}),
+                ResultEntry({"level": "INFO"}),
+                ResultEntry({"level": "WARN"}),
+            ]
+        )
+        assert not lc.contains_log("level", value="invalid")
+
+    def test_value_invalid_int_value(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"someId": 1}),
+                ResultEntry({"someId": 2}),
+                ResultEntry({"someId": 3}),
+                ResultEntry({"someId": 1}),
+                ResultEntry({"someId": 1}),
+            ]
+        )
+        assert not lc.contains_log("some_id", value=10)
 
 
-def test_log_container_add_multiple_logs():
-    lc = LogContainer()
-    lc.add_log(
-        [
+class TestGetLogsByField:
+    """
+    Tests for `get_logs_by_field`.
+    """
+
+    def test_both_pattern_and_value(self):
+        lc = LogContainer()
+        with pytest.raises(RuntimeError):
+            _ = lc.get_logs_by_field("level", pattern="pattern", value="value")
+
+    def test_neither_pattern_nor_value(self):
+        lc = LogContainer()
+        with pytest.raises(RuntimeError):
+            _ = lc.get_logs_by_field("level")
+
+    def test_pattern_str_ok(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG"}),
+                ResultEntry({"level": "INFO"}),
+                ResultEntry({"level": "WARN"}),
+            ]
+        )
+        logs = lc.get_logs_by_field("level", pattern=r"WARN|INFO")
+        assert len(logs) == 2
+        assert logs[0].level == "INFO"
+        assert logs[1].level == "WARN"
+
+    def test_pattern_int_ok(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"someId": 1}),
+                ResultEntry({"someId": 2}),
+                ResultEntry({"someId": 3}),
+                ResultEntry({"someId": 1}),
+                ResultEntry({"someId": 1}),
+                ResultEntry({"someId": 11}),
+                ResultEntry({"someId": 12}),
+            ]
+        )
+        logs = lc.get_logs_by_field("some_id", pattern=r"^1$")
+        assert len(logs) == 3
+        assert all(log.some_id == 1 for log in logs)
+
+    def test_pattern_cast_type(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG", "someId": "0"}),
+                ResultEntry({"level": "DEBUG", "someId": 0}),
+                ResultEntry({"level": "DEBUG", "someId": 6543}),
+                ResultEntry({"level": "DEBUG", "someId": "10"}),
+                ResultEntry({"level": "DEBUG", "someId": 100}),
+            ]
+        )
+        logs = lc.get_logs_by_field("some_id", pattern="^0$")
+        assert len(logs) == 2
+        assert logs[0].some_id == "0"
+        assert logs[1].some_id == 0
+
+        logs = lc.get_logs_by_field("some_id", pattern="0")
+        assert len(logs) == 4
+        assert logs[0].some_id == "0"
+        assert logs[1].some_id == 0
+        assert logs[2].some_id == "10"
+        assert logs[3].some_id == 100
+
+    def test_pattern_invalid_field(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG"}),
+                ResultEntry({"level": "INFO"}),
+                ResultEntry({"level": "WARN"}),
+            ]
+        )
+        logs = lc.get_logs_by_field("invalid", pattern="WARN")
+        assert len(logs) == 0
+
+    def test_pattern_invalid_value(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG"}),
+                ResultEntry({"level": "INFO"}),
+                ResultEntry({"level": "WARN"}),
+            ]
+        )
+        logs = lc.get_logs_by_field("level", pattern="invalid")
+        assert len(logs) == 0
+
+    def test_value_str_ok(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG"}),
+                ResultEntry({"level": "INFO"}),
+                ResultEntry({"level": "WARN"}),
+            ]
+        )
+        logs = lc.get_logs_by_field("level", value="INFO")
+        assert len(logs) == 1
+        assert logs[0].level == "INFO"
+
+    def test_value_int_ok(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"someId": 1}),
+                ResultEntry({"someId": 2}),
+                ResultEntry({"someId": 3}),
+                ResultEntry({"someId": 1}),
+                ResultEntry({"someId": 1}),
+                ResultEntry({"someId": 11}),
+                ResultEntry({"someId": 12}),
+            ]
+        )
+        logs = lc.get_logs_by_field("some_id", value=1)
+        assert len(logs) == 3
+        assert all(log.some_id == 1 for log in logs)
+
+    def test_value_none_ok(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG", "someId": 1}),
+                ResultEntry({"level": "DEBUG", "someId": 2}),
+                ResultEntry({"level": "INFO", "someId": None}),
+                ResultEntry({"level": "WARN", "someId": 2}),
+                ResultEntry({"level": "INFO", "someId": 1}),
+            ]
+        )
+        logs = lc.get_logs_by_field("some_id", value=None)
+        assert len(logs) == 1
+        assert logs[0].some_id is None
+
+    def test_value_filter_type(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG", "someId": "0"}),
+                ResultEntry({"level": "DEBUG", "someId": 0}),
+                ResultEntry({"level": "DEBUG", "someId": 6543}),
+                ResultEntry({"level": "DEBUG", "someId": "10"}),
+                ResultEntry({"level": "DEBUG", "someId": 100}),
+            ]
+        )
+        logs = lc.get_logs_by_field("some_id", value="0")
+        assert len(logs) == 1
+        assert logs[0].some_id == "0"
+
+        logs = lc.get_logs_by_field("some_id", value=0)
+        assert len(logs) == 1
+        assert logs[0].some_id == 0
+
+    def test_value_invalid_field(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG"}),
+                ResultEntry({"level": "INFO"}),
+                ResultEntry({"level": "WARN"}),
+            ]
+        )
+        logs = lc.get_logs_by_field("invalid", value="WARN")
+        assert len(logs) == 0
+
+    def test_value_invalid_str_value(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG"}),
+                ResultEntry({"level": "INFO"}),
+                ResultEntry({"level": "WARN"}),
+            ]
+        )
+        logs = lc.get_logs_by_field("level", value="invalid")
+        assert len(logs) == 0
+
+    def test_value_invalid_int_value(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"someId": 1}),
+                ResultEntry({"someId": 2}),
+                ResultEntry({"someId": 3}),
+                ResultEntry({"someId": 1}),
+                ResultEntry({"someId": 1}),
+            ]
+        )
+        logs = lc.get_logs_by_field("some_id", value=10)
+        assert len(logs) == 0
+
+
+class TestFindLog:
+    """
+    Tests for `find_log`.
+    """
+
+    def test_both_pattern_and_value(self):
+        lc = LogContainer()
+        with pytest.raises(RuntimeError):
+            _ = lc.find_log("level", pattern="pattern", value="value")
+
+    def test_neither_pattern_nor_value(self):
+        lc = LogContainer()
+        with pytest.raises(RuntimeError):
+            _ = lc.find_log("level")
+
+    def test_pattern_str_ok(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG"}),
+                ResultEntry({"level": "INFO"}),
+            ]
+        )
+        log = lc.find_log("level", pattern=r"WARN|INFO")
+        assert log
+        assert log.level == "INFO"
+
+    def test_pattern_int_ok(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"someId": 1}),
+                ResultEntry({"someId": 2}),
+                ResultEntry({"someId": 3}),
+                ResultEntry({"someId": 11}),
+                ResultEntry({"someId": 12}),
+            ]
+        )
+        log = lc.find_log("some_id", pattern=r"^1$")
+        assert log
+        assert log.some_id == 1
+
+    def test_pattern_many_found(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG"}),
+                ResultEntry({"level": "INFO"}),
+                ResultEntry({"level": "WARN"}),
+            ]
+        )
+        with pytest.raises(ValueError):
+            _ = lc.find_log("level", pattern=r"WARN|INFO")
+
+    def test_pattern_cast_type(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG", "someId": 0}),
+                ResultEntry({"level": "DEBUG", "someId": 6543}),
+                ResultEntry({"level": "DEBUG", "someId": "10"}),
+                ResultEntry({"level": "DEBUG", "someId": 100}),
+            ]
+        )
+        log = lc.find_log("some_id", pattern="^0$")
+        assert log
+        assert log.some_id == 0
+
+    def test_pattern_invalid_field(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG"}),
+                ResultEntry({"level": "INFO"}),
+                ResultEntry({"level": "WARN"}),
+            ]
+        )
+        assert lc.find_log("invalid", pattern="WARN") is None
+
+    def test_pattern_invalid_value(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG"}),
+                ResultEntry({"level": "INFO"}),
+                ResultEntry({"level": "WARN"}),
+            ]
+        )
+        assert lc.find_log("level", pattern="invalid") is None
+
+    def test_value_str_ok(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG"}),
+                ResultEntry({"level": "INFO"}),
+                ResultEntry({"level": "WARN"}),
+            ]
+        )
+        log = lc.find_log("level", value="INFO")
+        assert log
+        assert log.level == "INFO"
+
+    def test_value_int_ok(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"someId": 1}),
+                ResultEntry({"someId": 2}),
+                ResultEntry({"someId": 3}),
+                ResultEntry({"someId": 11}),
+                ResultEntry({"someId": 12}),
+            ]
+        )
+        log = lc.find_log("some_id", value=1)
+        assert log
+        assert log.some_id == 1
+
+    def test_value_none_ok(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG", "someId": 1}),
+                ResultEntry({"level": "DEBUG", "someId": 2}),
+                ResultEntry({"level": "INFO", "someId": None}),
+                ResultEntry({"level": "WARN", "someId": 2}),
+                ResultEntry({"level": "INFO", "someId": 1}),
+            ]
+        )
+        log = lc.find_log("some_id", value=None)
+        assert log
+        assert log.some_id is None
+
+    def test_value_filter_type(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG", "someId": "0"}),
+                ResultEntry({"level": "DEBUG", "someId": 0}),
+                ResultEntry({"level": "DEBUG", "someId": 6543}),
+                ResultEntry({"level": "DEBUG", "someId": "10"}),
+                ResultEntry({"level": "DEBUG", "someId": 100}),
+            ]
+        )
+        log = lc.find_log("some_id", value="0")
+        assert log
+        assert log.some_id == "0"
+
+        log = lc.find_log("some_id", value=0)
+        assert log
+        assert log.some_id == 0
+
+    def test_value_invalid_field(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG"}),
+                ResultEntry({"level": "INFO"}),
+                ResultEntry({"level": "WARN"}),
+            ]
+        )
+        assert lc.find_log("invalid", value="WARN") is None
+
+    def test_value_invalid_str_value(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG"}),
+                ResultEntry({"level": "INFO"}),
+                ResultEntry({"level": "WARN"}),
+            ]
+        )
+        assert lc.find_log("level", value="invalid") is None
+
+    def test_value_invalid_int_value(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"someId": 1}),
+                ResultEntry({"someId": 2}),
+                ResultEntry({"someId": 3}),
+                ResultEntry({"someId": 1}),
+                ResultEntry({"someId": 1}),
+            ]
+        )
+        assert lc.find_log("some_id", value=10) is None
+
+
+class TestAddLog:
+    """
+    Tests for `add_log`.
+    """
+
+    def _common_entries(self) -> list[ResultEntry]:
+        return [
             ResultEntry(
                 {
                     "timestamp": "0:00:01.000100",
@@ -69,328 +682,344 @@ def test_log_container_add_multiple_logs():
                 }
             ),
         ]
-    )
-    logs = lc.get_logs()
-    assert len(logs) == 2
 
-    assert logs[0].timestamp == str(timedelta(microseconds=1000100))
-    assert logs[0].level == "DEBUG"
-    assert logs[0].message == "Debug message"
-    assert logs[0].target == "target::DEBUG_message"
-    assert logs[0].thread_id == "ThreadId(1)"
+    def _common_check(self, lc: LogContainer) -> None:
+        logs = lc.get_logs()
+        assert len(logs) == 2
 
-    assert logs[1].timestamp == str(timedelta(microseconds=1000101))
-    assert logs[1].level == "INFO"
-    assert logs[1].target == "target::INFO_message"
-    assert logs[1].thread_id == "ThreadId(2)"
+        assert logs[0].timestamp == str(timedelta(microseconds=1000100))
+        assert logs[0].level == "DEBUG"
+        assert logs[0].message == "Debug message"
+        assert logs[0].target == "target::DEBUG_message"
+        assert logs[0].thread_id == "ThreadId(1)"
+
+        assert logs[1].timestamp == str(timedelta(microseconds=1000101))
+        assert logs[1].level == "INFO"
+        assert logs[1].target == "target::INFO_message"
+        assert logs[1].thread_id == "ThreadId(2)"
+
+    def test_single_ok(self):
+        lc = LogContainer()
+        for entry in self._common_entries():
+            lc.add_log(entry)
+        self._common_check(lc)
+
+    def test_single_param_copied_not_referenced(self):
+        logs = [ResultEntry({})]
+        lc = LogContainer(logs)
+        lc.add_log(ResultEntry({}))
+
+        assert len(logs) == 1
+        assert len(lc.get_logs()) == 2
+
+    def test_many_ok(self):
+        lc = LogContainer()
+        lc.add_log(self._common_entries())
+        self._common_check(lc)
+
+    def test_many_param_copied_not_referenced(self):
+        logs1 = [ResultEntry({}), ResultEntry({})]
+        lc = LogContainer(logs1)
+        logs2 = [ResultEntry({}), ResultEntry({}), ResultEntry({})]
+        lc.add_log(logs2)
+
+        assert len(logs1) == 2
+        assert len(logs2) == 3
+        assert len(lc.get_logs()) == 5
+
+    @pytest.mark.parametrize("value", ["raw_string", None, 123, False])
+    def test_invalid_type(self, value: Any):
+        lc = LogContainer()
+        with pytest.raises(TypeError):
+            lc.add_log(value)  # type: ignore
 
 
-def test_log_container_add_raw_string():
-    lc = LogContainer()
-    with pytest.raises(TypeError):
-        lc.add_log("raw_string_example")  # type: ignore
+class TestGetLogs:
+    """
+    Tests for `get_logs`.
+    """
+
+    def test_ok(self, lc_basic: LogContainer):
+        logs = lc_basic.get_logs()
+        assert len(logs) == 10
+        assert all(log.index == i for i, log in enumerate(logs))
+
+    def test_empty(self):
+        lc = LogContainer()
+        logs = lc.get_logs()
+        assert len(logs) == 0
 
 
-def test_log_container_find_log():
-    lc = LogContainer()
-    lc.add_log(
-        ResultEntry(
-            {
-                "timestamp": "0:01:01.000100",
-                "level": "DEBUG",
-                "fields": {"message": "Debug message"},
-                "target": "target::DEBUG_message",
-                "threadId": "ThreadId(1)",
-            }
+class TestClearLogs:
+    """
+    Tests for `clear_logs`.
+    """
+
+    def test_ok(self, lc_basic: LogContainer):
+        lc_basic.clear_logs()
+        assert lc_basic.get_logs() == []
+
+
+class TestRemoveLogs:
+    """
+    Tests for `remove_logs`.
+    """
+
+    def test_both_pattern_and_value(self):
+        lc = LogContainer()
+        with pytest.raises(RuntimeError):
+            _ = lc.remove_logs("level", pattern="pattern", value="value")
+
+    def test_neither_pattern_nor_value(self):
+        lc = LogContainer()
+        with pytest.raises(RuntimeError):
+            _ = lc.remove_logs("level")
+
+    def test_pattern_str_ok(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG"}),
+                ResultEntry({"level": "INFO"}),
+                ResultEntry({"level": "WARN"}),
+            ]
         )
-    )
-    lc.add_log(
-        ResultEntry(
-            {
-                "timestamp": "0:01:01.000100",
-                "level": "INFO",
-                "target": "target::INFO_message",
-                "threadId": "ThreadId(2)",
-            }
+        lc.remove_logs("level", pattern=r"WARN|INFO")
+
+        logs = lc.get_logs()
+        assert len(logs) == 1
+        assert logs[0].level == "DEBUG"
+
+    def test_pattern_int_ok(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"someId": 1}),
+                ResultEntry({"someId": 2}),
+                ResultEntry({"someId": 3}),
+                ResultEntry({"someId": 1}),
+                ResultEntry({"someId": 1}),
+                ResultEntry({"someId": 11}),
+                ResultEntry({"someId": 12}),
+            ]
         )
-    )
-    log = lc.find_log("target", "target::DEBUG*")
-    assert log
-    assert log.message == "Debug message"
+        lc.remove_logs("some_id", pattern=r"^1$")
 
-    log = lc.find_log("level", "INFO")
-    assert log
-    assert log.target == "target::INFO_message"
+        logs = lc.get_logs()
+        assert len(logs) == 4
+        assert logs[0].some_id == 2
+        assert logs[1].some_id == 3
+        assert logs[2].some_id == 11
+        assert logs[3].some_id == 12
 
-
-def test_log_container_get_logs_by_field():
-    lc = LogContainer()
-    lc.add_log(
-        ResultEntry(
-            {
-                "timestamp": "0:01:01.000100",
-                "level": "DEBUG",
-                "fields": {"message": "Debug message 1"},
-                "target": "target::DEBUG_message",
-                "threadId": "ThreadId(1)",
-            }
+    def test_pattern_cast_type(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG", "someId": "0"}),
+                ResultEntry({"level": "DEBUG", "someId": 0}),
+                ResultEntry({"level": "DEBUG", "someId": 6543}),
+                ResultEntry({"level": "DEBUG", "someId": "10"}),
+                ResultEntry({"level": "DEBUG", "someId": 100}),
+            ]
         )
-    )
-    lc.add_log(
-        ResultEntry(
-            {
-                "timestamp": "0:01:01.000100",
-                "level": "DEBUG",
-                "fields": {"message": "Debug message 2"},
-                "target": "target::DEBUG_message",
-                "threadId": "ThreadId(2)",
-            }
+        lc.remove_logs("some_id", pattern="^0$")
+
+        logs = lc.get_logs()
+        assert len(logs) == 3
+        assert logs[0].some_id == 6543
+        assert logs[1].some_id == "10"
+        assert logs[2].some_id == 100
+
+    def test_pattern_invalid_field(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG"}),
+                ResultEntry({"level": "INFO"}),
+                ResultEntry({"level": "WARN"}),
+            ]
         )
-    )
-    logs = lc.get_logs_by_field("level", "DEBUG")
-    assert len(list(logs)) == 2
-    assert logs[0].message == "Debug message 1"
-    assert logs[1].message == "Debug message 2"
+        lc.remove_logs("invalid", pattern="WARN")
+        assert len(lc) == 3
 
-
-def test_log_container_clear_logs():
-    lc = LogContainer()
-    lc.add_log(
-        ResultEntry(
-            {
-                "timestamp": "0:00:01.000100",
-                "level": "INFO",
-                "fields": {"message": "Info message"},
-                "target": "target::INFO_message",
-                "threadId": "ThreadId(2)",
-            }
+    def test_pattern_invalid_value(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG"}),
+                ResultEntry({"level": "INFO"}),
+                ResultEntry({"level": "WARN"}),
+            ]
         )
-    )
-    lc.clear_logs()
-    assert lc.get_logs() == []
+        lc.remove_logs("level", pattern="invalid")
+        assert len(lc) == 3
 
-
-def test_log_container_groups():
-    lc = LogContainer()
-    lc.add_log(
-        ResultEntry(
-            {
-                "timestamp": "0:00:00.000001",
-                "level": "INFO",
-                "fields": {"message": "Info message 1"},
-                "target": "target::INFO_message",
-                "threadId": "ThreadId(2)",
-            }
+    def test_value_str_ok(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG"}),
+                ResultEntry({"level": "INFO"}),
+                ResultEntry({"level": "WARN"}),
+            ]
         )
-    )
-    lc.add_log(
-        ResultEntry(
-            {
-                "timestamp": "0:00:00.000002",
-                "level": "INFO",
-                "fields": {"message": "Info message 2"},
-                "target": "target::INFO_message",
-                "threadId": "ThreadId(1)",
-            }
+        lc.remove_logs("level", value="INFO")
+
+        logs = lc.get_logs()
+        assert len(logs) == 2
+        assert logs[0].level == "DEBUG"
+        assert logs[1].level == "WARN"
+
+    def test_value_int_ok(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"someId": 1}),
+                ResultEntry({"someId": 2}),
+                ResultEntry({"someId": 3}),
+                ResultEntry({"someId": 1}),
+                ResultEntry({"someId": 1}),
+                ResultEntry({"someId": 11}),
+                ResultEntry({"someId": 12}),
+            ]
         )
-    )
-    lc.add_log(
-        ResultEntry(
-            {
-                "timestamp": "0:00:00.000003",
-                "level": "INFO",
-                "fields": {"message": "Info message 3"},
-                "target": "target::INFO_message",
-                "threadId": "ThreadId(2)",
-            }
+        lc.remove_logs("some_id", value=1)
+
+        logs = lc.get_logs()
+        assert len(logs) == 4
+        assert logs[0].some_id == 2
+        assert logs[1].some_id == 3
+        assert logs[2].some_id == 11
+        assert logs[3].some_id == 12
+
+    def test_value_none_ok(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG", "someId": 1}),
+                ResultEntry({"level": "DEBUG", "someId": 2}),
+                ResultEntry({"level": "INFO", "someId": None}),
+                ResultEntry({"level": "WARN", "someId": 2}),
+                ResultEntry({"level": "INFO", "someId": 1}),
+            ]
         )
-    )
-    groups = lc.group_by("thread_id")
-    assert len(groups) == 2
-    assert len(groups["ThreadId(1)"]) == 1
-    assert len(groups["ThreadId(2)"]) == 2
-    assert groups["ThreadId(1)"][0].message == "Info message 2"
-    assert groups["ThreadId(2)"][0].message == "Info message 1"
-    assert groups["ThreadId(2)"][1].message == "Info message 3"
+        lc.remove_logs("some_id", value=None)
+
+        logs = lc.get_logs()
+        assert len(logs) == 4
+        assert all(log is not None for log in logs)
+
+    def test_value_filter_type(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG", "someId": "0"}),
+                ResultEntry({"level": "DEBUG", "someId": 0}),
+                ResultEntry({"level": "DEBUG", "someId": 6543}),
+                ResultEntry({"level": "DEBUG", "someId": "10"}),
+                ResultEntry({"level": "DEBUG", "someId": 100}),
+            ]
+        )
+
+        lc.remove_logs("some_id", value="0")
+        logs = lc.get_logs()
+        assert len(logs) == 4
+        assert logs[0].some_id == 0
+        assert logs[1].some_id == 6543
+        assert logs[2].some_id == "10"
+        assert logs[3].some_id == 100
+
+        lc.remove_logs("some_id", value=0)
+        logs = lc.get_logs()
+        assert len(logs) == 3
+        assert logs[0].some_id == 6543
+        assert logs[1].some_id == "10"
+        assert logs[2].some_id == 100
+
+    def test_value_invalid_field(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG"}),
+                ResultEntry({"level": "INFO"}),
+                ResultEntry({"level": "WARN"}),
+            ]
+        )
+        lc.remove_logs("invalid", value="WARN")
+        assert len(lc) == 3
+
+    def test_value_invalid_str_value(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"level": "DEBUG"}),
+                ResultEntry({"level": "INFO"}),
+                ResultEntry({"level": "WARN"}),
+            ]
+        )
+        lc.remove_logs("level", value="invalid")
+        assert len(lc) == 3
+
+    def test_value_invalid_int_value(self):
+        lc = LogContainer()
+        lc.add_log(
+            [
+                ResultEntry({"someId": 1}),
+                ResultEntry({"someId": 2}),
+                ResultEntry({"someId": 3}),
+                ResultEntry({"someId": 1}),
+                ResultEntry({"someId": 1}),
+            ]
+        )
+        lc.remove_logs("some_id", value=10)
+        assert len(lc) == 5
 
 
-def test_log_container_init_entries_default_not_referenced() -> None:
-    lc1 = LogContainer()
-    lc1.add_log(ResultEntry({}))
-    lc2 = LogContainer()
-    lc2.add_log(ResultEntry({}))
+class TestGroupBy:
+    """
+    Tests for `group_by`.
+    """
 
-    assert len(lc1.get_logs()) == 1
-    assert len(lc2.get_logs()) == 1
-
-
-def test_log_container_init_entries_copied_not_referenced() -> None:
-    logs1 = [ResultEntry({})]
-    lc1 = LogContainer(logs1)
-    lc1.add_log(ResultEntry({}))
-    lc2 = LogContainer()
-    lc2.add_log(ResultEntry({}))
-
-    assert len(logs1) == 1
-    assert len(lc1.get_logs()) == 2
-    assert len(lc2.get_logs()) == 1
-
-
-def test_log_container_single_add_log_copied_not_referenced() -> None:
-    logs = [ResultEntry({})]
-    lc = LogContainer(logs)
-    lc.add_log(ResultEntry({}))
-
-    assert len(logs) == 1
-    assert len(lc.get_logs()) == 2
-
-
-def test_log_container_many_add_log_copied_not_referenced() -> None:
-    logs1 = [ResultEntry({}), ResultEntry({})]
-    lc = LogContainer(logs1)
-    logs2 = [ResultEntry({}), ResultEntry({}), ResultEntry({})]
-    lc.add_log(logs2)
-
-    assert len(logs1) == 2
-    assert len(logs2) == 3
-    assert len(lc.get_logs()) == 5
-
-
-def test_log_container_get_logs_by_field_str():
-    lc = LogContainer()
-    lc.add_log(
-        [
-            ResultEntry({"level": "DEBUG"}),
-            ResultEntry({"level": "INFO"}),
-            ResultEntry({"level": "WARN"}),
-        ]
-    )
-    logs = lc.get_logs_by_field("level", r"WARN|INFO")
-    assert len(logs) == 2
-    assert logs[0].level == "INFO"
-    assert logs[1].level == "WARN"
-
-
-def test_log_container_get_logs_by_field_int():
-    lc = LogContainer()
-    lc.add_log(
-        [
-            ResultEntry({"someId": 1}),
-            ResultEntry({"someId": 2}),
-            ResultEntry({"someId": 3}),
-            ResultEntry({"someId": 1}),
-            ResultEntry({"someId": 1}),
-        ]
-    )
-    logs = lc.get_logs_by_field("some_id", 1)
-    assert len(logs) == 3
-    assert all(log.some_id == 1 for log in logs)
-
-
-def test_log_container_get_logs_by_field_none():
-    lc = LogContainer()
-    lc.add_log(
-        [
-            ResultEntry({"level": "DEBUG", "someId": 1}),
-            ResultEntry({"level": "DEBUG", "someId": 2}),
-            ResultEntry({"level": "INFO", "someId": None}),
-            ResultEntry({"level": "WARN", "someId": 2}),
-            ResultEntry({"level": "INFO", "someId": 1}),
-        ]
-    )
-    logs = lc.get_logs_by_field("some_id", None)
-    assert len(logs) == 1
-    assert logs[0].some_id is None
-
-
-def test_log_container_get_logs_by_field_filter_type():
-    lc = LogContainer()
-    lc.add_log(
-        [
-            ResultEntry({"level": "DEBUG", "someId": "0"}),
-            ResultEntry({"level": "DEBUG", "someId": 0}),
-        ]
-    )
-    logs = lc.get_logs_by_field("some_id", "0")
-    assert len(logs) == 1
-    assert logs[0].some_id == "0"
-
-    logs = lc.get_logs_by_field("some_id", 0)
-    assert len(logs) == 1
-    assert logs[0].some_id == 0
-
-
-def test_log_container_get_logs_by_field_invalid_key():
-    lc = LogContainer()
-    lc.add_log(
-        [
-            ResultEntry({"level": "DEBUG"}),
-            ResultEntry({"level": "INFO"}),
-            ResultEntry({"level": "WARN"}),
-        ]
-    )
-    logs = lc.get_logs_by_field("invalid_entry", "invalid_pattern")
-    assert len(logs) == 0
-
-
-def test_log_container_get_logs_by_field_invalid_pattern_str():
-    lc = LogContainer()
-    lc.add_log(
-        [
-            ResultEntry({"level": "DEBUG"}),
-            ResultEntry({"level": "INFO"}),
-            ResultEntry({"level": "WARN"}),
-        ]
-    )
-    logs = lc.get_logs_by_field("level", "invalid_pattern")
-    assert len(logs) == 0
-
-
-def test_log_container_get_logs_by_field_invalid_pattern_int():
-    lc = LogContainer()
-    lc.add_log(
-        [
-            ResultEntry({"someId": 1}),
-            ResultEntry({"someId": 2}),
-            ResultEntry({"someId": 3}),
-            ResultEntry({"someId": 1}),
-            ResultEntry({"someId": 1}),
-        ]
-    )
-    logs = lc.get_logs_by_field("some_id", 10)
-    assert len(logs) == 0
-
-
-def test_log_container_remove_logs_str():
-    lc = LogContainer()
-    lc.add_log(
-        [
-            ResultEntry({"level": "DEBUG"}),
-            ResultEntry({"level": "INFO"}),
-            ResultEntry({"level": "WARN"}),
-        ]
-    )
-    lc.remove_logs("level", r"WARN|INFO")
-
-    logs = lc.get_logs()
-    assert len(logs) == 1
-    assert logs[0].level == "DEBUG"
-
-
-def test_log_container_remove_logs_int():
-    lc = LogContainer()
-    lc.add_log(
-        [
-            ResultEntry({"someId": 1}),
-            ResultEntry({"someId": 2}),
-            ResultEntry({"someId": 3}),
-            ResultEntry({"someId": 1}),
-            ResultEntry({"someId": 1}),
-        ]
-    )
-    lc.remove_logs("some_id", 1)
-
-    logs = lc.get_logs()
-    assert len(logs) == 2
-    assert logs[0].some_id == 2
-    assert logs[1].some_id == 3
+    def test_ok(self):
+        lc = LogContainer()
+        lc.add_log(
+            ResultEntry(
+                {
+                    "timestamp": "0:00:00.000001",
+                    "level": "INFO",
+                    "fields": {"message": "Info message 1"},
+                    "target": "target::INFO_message",
+                    "threadId": "ThreadId(2)",
+                }
+            )
+        )
+        lc.add_log(
+            ResultEntry(
+                {
+                    "timestamp": "0:00:00.000002",
+                    "level": "INFO",
+                    "fields": {"message": "Info message 2"},
+                    "target": "target::INFO_message",
+                    "threadId": "ThreadId(1)",
+                }
+            )
+        )
+        lc.add_log(
+            ResultEntry(
+                {
+                    "timestamp": "0:00:00.000003",
+                    "level": "INFO",
+                    "fields": {"message": "Info message 3"},
+                    "target": "target::INFO_message",
+                    "threadId": "ThreadId(2)",
+                }
+            )
+        )
+        groups = lc.group_by("thread_id")
+        assert len(groups) == 2
+        assert len(groups["ThreadId(1)"]) == 1
+        assert len(groups["ThreadId(2)"]) == 2
+        assert groups["ThreadId(1)"][0].message == "Info message 2"
+        assert groups["ThreadId(2)"][0].message == "Info message 1"
+        assert groups["ThreadId(2)"][1].message == "Info message 3"

--- a/tests/test_log_container.py
+++ b/tests/test_log_container.py
@@ -302,6 +302,24 @@ def test_log_container_get_logs_by_field_none():
     assert len(logs) == 1
     assert logs[0].some_id is None
 
+
+def test_log_container_get_logs_by_field_filter_type():
+    lc = LogContainer()
+    lc.add_log(
+        [
+            ResultEntry({"level": "DEBUG", "someId": "0"}),
+            ResultEntry({"level": "DEBUG", "someId": 0}),
+        ]
+    )
+    logs = lc.get_logs_by_field("some_id", "0")
+    assert len(logs) == 1
+    assert logs[0].some_id == "0"
+
+    logs = lc.get_logs_by_field("some_id", 0)
+    assert len(logs) == 1
+    assert logs[0].some_id == 0
+
+
 def test_log_container_get_logs_by_field_invalid_key():
     lc = LogContainer()
     lc.add_log(
@@ -314,6 +332,7 @@ def test_log_container_get_logs_by_field_invalid_key():
     logs = lc.get_logs_by_field("invalid_entry", "invalid_pattern")
     assert len(logs) == 0
 
+
 def test_log_container_get_logs_by_field_invalid_pattern_str():
     lc = LogContainer()
     lc.add_log(
@@ -325,6 +344,7 @@ def test_log_container_get_logs_by_field_invalid_pattern_str():
     )
     logs = lc.get_logs_by_field("level", "invalid_pattern")
     assert len(logs) == 0
+
 
 def test_log_container_get_logs_by_field_invalid_pattern_int():
     lc = LogContainer()
@@ -339,6 +359,7 @@ def test_log_container_get_logs_by_field_invalid_pattern_int():
     )
     logs = lc.get_logs_by_field("some_id", 10)
     assert len(logs) == 0
+
 
 def test_log_container_remove_logs_str():
     lc = LogContainer()


### PR DESCRIPTION
- Version bump to "0.1.1".

`log_container.py`:
- Allow exact and regex matching in filters.
- Improved `log_container` module docs - uniform phrasing, minor fixes, description of parameters.
- Removed `contains_id` function - it was specific to a single orch test, and duplicated responsibility with `contains_log`.
- Removed `clear_logs` - duplicate functionality with `LogContainer()`.
- `remove_logs` is now providing filtered copy of `LogContainer`.

Tests:
- Renamed `test_log_container_and_result_entry.py` to `test_log_container.py`
- Full public `LogContainer` APIs tests.