### PR TITLE
impl: revert 'expect_command_failure'

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,7 +4,7 @@
 
 module(
     name = "testing-utils",
-    version = "0.2.1",
+    version = "0.2.2",
 )
 
 # Python rules.

--- a/README.md
+++ b/README.md
@@ -214,17 +214,8 @@ To capture `stderr` use:
 
 ```python
 class TestExample(Scenario):
-    capture_stderr = True
-
-    ...
-```
-
-Execution command is checked against non-zero return code or a hang.
-To expect such conditions and handle them in the test use:
-
-```python
-class TestExample(Scenario):
-    expect_command_failure = True
+    def capture_stderr(self) -> bool:
+        return True
 
     ...
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "testing-utils"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = ["pytest==8.4.1", "pytest-html==4.1.1", "pytest-repeat==0.9.4"]
 requires-python = ">=3.12"
 authors = [

--- a/test_scenarios_rust/Cargo.lock
+++ b/test_scenarios_rust/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "test_scenarios_rust"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "tracing",
  "tracing-subscriber",

--- a/test_scenarios_rust/Cargo.toml
+++ b/test_scenarios_rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_scenarios_rust"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 [dependencies]

--- a/testing_utils/scenario.py
+++ b/testing_utils/scenario.py
@@ -40,25 +40,11 @@ class ScenarioResult:
             field_reprs.append(f"{name}={repr(value)}")
         return f"{class_name}({', '.join(field_reprs)})"
 
-    def is_successful(self) -> bool:
-        """
-        Check if the execution was successful.
-
-        Successful means zero return code and no hang.
-        """
-        return self.return_code == 0 and not self.hang
-
 
 class Scenario(ABC):
     """
     Base test scenario definition.
     """
-
-    # Capture or display stderr during execution.
-    capture_stderr: bool = False
-
-    # Whether command failure (non-zero return code or hang) is expected.
-    expect_command_failure: bool = False
 
     @pytest.fixture(scope="class")
     @abstractmethod
@@ -96,6 +82,12 @@ class Scenario(ABC):
             return timeout
         return 5.0
 
+    def capture_stderr(self, *args, **kwargs) -> bool:
+        """
+        Capture or display stderr during execution.
+        """
+        return False
+
     @pytest.fixture(scope="class")
     def target_path(self, build_tools: BuildTools, request: FixtureRequest) -> Path:
         """
@@ -126,6 +118,29 @@ class Scenario(ABC):
         test_config_str = json.dumps(test_config)
         return [str(target_path), "--name", scenario_name, "--input", test_config_str]
 
+    def _run_command(self, command: list[str], execution_timeout: float, *args, **kwargs) -> ScenarioResult:
+        """
+        Execute test scenario executable.
+
+        Parameters
+        ----------
+        command : list[str]
+            Command to invoke.
+        execution_timeout : float
+            Test execution timeout in seconds.
+        """
+        hang = False
+        stderr_param = PIPE if self.capture_stderr() else None
+        with Popen(command, stdout=PIPE, stderr=stderr_param, text=True) as p:
+            try:
+                stdout, stderr = p.communicate(timeout=execution_timeout)
+            except TimeoutExpired:
+                hang = True
+                p.kill()
+                stdout, stderr = p.communicate()
+
+        return ScenarioResult(stdout, stderr, p.returncode, hang)
+
     @pytest.fixture(scope="class")
     def results(
         self,
@@ -144,19 +159,7 @@ class Scenario(ABC):
         execution_timeout : float
             Test execution timeout in seconds.
         """
-        # Run scenario.
-        hang = False
-
-        stderr_param = PIPE if self.capture_stderr else None
-        with Popen(command, stdout=PIPE, stderr=stderr_param, text=True) as p:
-            try:
-                stdout, stderr = p.communicate(timeout=execution_timeout)
-            except TimeoutExpired:
-                hang = True
-                p.kill()
-                stdout, stderr = p.communicate()
-
-        return ScenarioResult(stdout, stderr, p.returncode, hang)
+        return self._run_command(command, execution_timeout, args, kwargs)
 
     @pytest.fixture(scope="class")
     def logs(self, results: ScenarioResult, *args, **kwargs) -> LogContainer:
@@ -181,13 +184,6 @@ class Scenario(ABC):
 
         # Sort messages into chronological order.
         messages.sort(key=lambda m: m["timestamp"])
-
-        result_success = results.is_successful()
-        if self.expect_command_failure and result_success:
-            raise RuntimeError(f"Command execution succeeded unexpectedly: {results=}")
-
-        if not self.expect_command_failure and not result_success:
-            raise RuntimeError(f"Command execution failed unexpectedly: {results=}")
 
         # Convert messages to list of ResultEntry and create log container.
         result_entries = [ResultEntry(msg) for msg in messages]


### PR DESCRIPTION
- Version bumped (due to other changes).
- Removed 'expect_command_failure' - to be moved to orch.
- Add '_run_command' method to 'Scenario'.
- Restored 'capture_stderr' method.